### PR TITLE
Update __init__.py / add attribute priority

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/__init__.py
+++ b/script.module.resolveurl/lib/resolveurl/__init__.py
@@ -64,7 +64,7 @@ def load_external_plugins():
                 common.logger.log_debug('Loaded %s as %s from %s' % (imp, mod_name, filename))
 
 
-def relevant_resolvers(domain=None, include_universal=None, include_popups=None, include_external=False, include_disabled=False, order_matters=False):
+def relevant_resolvers(domain=None, include_universal=None, include_popups=None, include_external=False, include_disabled=False, order_matters=False, priority=False):
     if include_external:
         load_external_plugins()
 
@@ -89,6 +89,10 @@ def relevant_resolvers(domain=None, include_universal=None, include_popups=None,
 
     if order_matters:
         relevant.sort(key=lambda x: x._get_priority())
+    
+    # Add attribute priority
+    if priority:
+        for i in relevant: i.priority = i._get_priority()
 
     common.logger.log_debug('Relevant Resolvers: %s' % relevant)
     return relevant


### PR DESCRIPTION
Adding the “priority” attribute to the elements of “relevant” in the relevant_resolvers() function

facilitates access to the “priority” property for addons that use resolveurl 

